### PR TITLE
Allow ink function to run on each redacted field individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,36 @@ $redactor = (new ArrayRedactor($login, ['password', 'session_id']))->ink(null)->
 ];
 ```
 
+If the value you pass into the third constructor argument or the `->ink()` method is callable, it will be invoked when redacting each value, and its return value will be used as the redacted value in the result:
+
+```php
+$login = [
+    'email' => 'john_doe@domain.com',
+    'password' => 'secret123',
+    'data' => [
+        'session_id' => 'z481jf0an4kasnc8a84aj831'
+    ],
+];
+
+$ink_function = function (string $val): string {
+    return mb_substr($val, 0, 1) . str_repeat('*', mb_strlen($val) - 2) . mb_substr($val, mb_strlen($val) - 1, 1);
+};
+
+$redactor = (new ArrayRedactor($login, ['password', 'session_id'], $ink_function))->redact();
+// or...
+$redactor = (new ArrayRedactor($login, ['password', 'session_id']))->ink($ink_function)->redact();
+
+// $redactor will return:
+[
+    'email' => 'john_doe@domain.com',
+    'password' => 's*******3'
+    'data' => [
+        'session_id' => 'z**********************1'
+    ],
+];
+
+```
+
 You can call the ``ArrayRedactor`` as a function and the magic ``__invoke()`` method will call the ``redact`` method for you.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -162,20 +162,20 @@ $login = [
     ],
 ];
 
-$ink_function = function (string $val): string {
-    return mb_substr($val, 0, 1) . str_repeat('*', mb_strlen($val) - 2) . mb_substr($val, mb_strlen($val) - 1, 1);
+$ink_function = function($val, $key) {
+    return $key === 'email' ? substr($val, stripos($val, '@')) : '[REDACTED]';
 };
 
-$redactor = (new ArrayRedactor($login, ['password', 'session_id'], $ink_function))->redact();
+$redactor = (new ArrayRedactor($login, ['email', 'password', 'session_id'], $ink_function))->redact();
 // or...
-$redactor = (new ArrayRedactor($login, ['password', 'session_id']))->ink($ink_function)->redact();
+$redactor = (new ArrayRedactor($login, ['email', 'password', 'session_id']))->ink($ink_function)->redact();
 
 // $redactor will return:
 [
-    'email' => 'john_doe@domain.com',
-    'password' => 's*******3'
+    'email' => '@domain.com',
+    'password' => '[REDACTED]'
     'data' => [
-        'session_id' => 'z**********************1'
+        'session_id' => '[REDACTED]'
     ],
 ];
 

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         ]
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.4|>=8.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "^6.4"
+      "phpunit/phpunit": "^9"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ArrayRedactor.php
+++ b/src/ArrayRedactor.php
@@ -77,7 +77,7 @@ class ArrayRedactor
      */
     public function ink($ink = '[REDACTED]')
     {
-        $this->ink = is_callable($ink) ? $ink() : $ink;
+        $this->ink = $ink;
         return $this;
     }
 
@@ -99,7 +99,7 @@ class ArrayRedactor
         // Recursively traverse the array and redact the specified keys
         array_walk_recursive($this->content, function (&$value, $key) {
             if (in_array($key, $this->keys, true)) {
-                $value = is_callable($ink) ? $ink($value) : $this->ink;
+                $value = is_callable($this->ink) ? call_user_func($this->ink, $value, $key) : $this->ink;
             }
         });
 

--- a/src/ArrayRedactor.php
+++ b/src/ArrayRedactor.php
@@ -99,7 +99,7 @@ class ArrayRedactor
         // Recursively traverse the array and redact the specified keys
         array_walk_recursive($this->content, function (&$value, $key) {
             if (in_array($key, $this->keys, true)) {
-                $value = $this->ink;
+                $value = is_callable($ink) ? $ink($value) : $this->ink;
             }
         });
 

--- a/tests/ArrayRedactorTest.php
+++ b/tests/ArrayRedactorTest.php
@@ -6,7 +6,7 @@ use Mtownsend\ArrayRedactor\ArrayRedactor;
 
 class ArrayRedactorTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
     	$this->content = [
     		'email' => 'mtownsend5512@gmail.com',
@@ -98,10 +98,11 @@ class ArrayRedactorTest extends TestCase
     /** @test */
     public function can_accept_closure_in_ink()
     {
-        $array = $this->content;
-        $result = (new ArrayRedactor())->content($this->content)->keys(['email'])->ink(function() use ($array) {
-            return substr($array['email'], stripos($array['email'], '@'));
-        })->redact();
+        $func = function(string $val, string $key): string {
+            return $key === 'email' ? substr($val, stripos($val, '@')) : $val;
+        };
+
+        $result = (new ArrayRedactor())->content($this->content)->keys(['email'])->ink($func)->redact();
         $this->assertEquals(array_merge($this->content, [
             'email' => '@gmail.com'
         ]), $result);


### PR DESCRIPTION
I've made a slight modification so that the ink function is called each time a field is redacted instead of being called once when set (which would basically mean the developer had to run the entire redaction on their own copy of the data?)

I've also added a note about this option to the readme, updated the test, and taken the liberty of upgrading the supported php versions in composer.json